### PR TITLE
fix: Correct unit test failures for SongLyricsService

### DIFF
--- a/lyrics_service.rb
+++ b/lyrics_service.rb
@@ -83,6 +83,6 @@ class SongLyricsService < LyricsService
 
     doc = Nokogiri::HTML(response.body.to_s)
     lyrics_div = doc.css('#songLyricsDiv').first
-    lyrics_div ? lyrics_div.inner_html.gsub('<br>', "\n").strip : ''
+    lyrics_div ? lyrics_div.inner_html.gsub('<br>', "\n").gsub(/(\n\s*)+/, "\n").strip : ''
   end
 end

--- a/spec/lyrics_service_spec.rb
+++ b/spec/lyrics_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SongLyricsService do
 
   describe '#search' do
     it 'returns a list of songs' do
-      stub_request(:get, /www.songlyrics.com\/index.php\?section=search&searchW=test/).
+      stub_request(:get, "http://www.songlyrics.com/index.php?section=search&searchW=test").
         to_return(body: File.read('spec/fixtures/songlyrics_search.html'))
 
       results = service.search('test')


### PR DESCRIPTION
This commit fixes two failing unit tests for the `SongLyricsService`.

- The `search` test was failing due to a `WebMock::NetConnectNotAllowedError`. This was caused by an incorrect URL stub. The stub has been updated to match the actual URL being requested.
- The `fetch_lyrics` test was failing due to extra whitespace in the returned lyrics. The `fetch_lyrics` method has been updated to correctly handle whitespace and newlines.