### PR TITLE
fix: Upgrade Sinatra and restore Rack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'sinatra', '4.0.0'
+gem 'sinatra', '~> 4.1'
 gem 'rack', '~> 3.0'
 gem 'rack-cors'
 gem 'json'


### PR DESCRIPTION
This commit upgrades Sinatra to `~> 4.1` and restores Rack to `~> 3.0`. This is to address the `NameError: uninitialized constant Rack::Logger` which was caused by an incompatibility between Sinatra 4.0.0 and Rack 3.x.

The new version of Sinatra has better compatibility with Rack 3, which should resolve the issue without the need to downgrade Rack.