### PR TITLE
feat: Add logging to SongLyricsService

### DIFF
--- a/lyrics_service.rb
+++ b/lyrics_service.rb
@@ -58,11 +58,13 @@ class SongLyricsService < LyricsService
 
   def search(term)
     search_url = "#{BASE_URL}/index.php?section=search&searchW=#{URI.encode_www_form_component(term)}"
+    puts "Searching for: #{search_url}"
     response = HTTP.get(search_url)
+    puts "Response status: #{response.status}"
     return [] unless response.status.success?
 
     doc = Nokogiri::HTML(response.body.to_s)
-    doc.css('div.serp-item').map do |item|
+    results = doc.css('div.serp-item').map do |item|
       title_element = item.css('h3 a').first
       artist_element = item.css('p a').first
       next unless title_element && artist_element
@@ -75,6 +77,9 @@ class SongLyricsService < LyricsService
         }
       }
     end.compact
+    puts "Found #{results.size} results."
+    puts "First result: #{results.first}"
+    results
   end
 
   def fetch_lyrics(track_id)


### PR DESCRIPTION
This commit adds logging to the `search` method of the `SongLyricsService` to help diagnose why the search is not returning any results.

The following information is logged:
- The URL being requested.
- The status of the HTTP response.
- The number of search results found.
- The first search result.