### PR TITLE
feat: Add logging for HTML response body

### DIFF
--- a/lyrics_service.rb
+++ b/lyrics_service.rb
@@ -61,6 +61,7 @@ class SongLyricsService < LyricsService
     puts "Searching for: #{search_url}"
     response = HTTP.get(search_url)
     puts "Response status: #{response.status}"
+    puts "Response body: #{response.body.to_s}"
     return [] unless response.status.success?
 
     doc = Nokogiri::HTML(response.body.to_s)


### PR DESCRIPTION
This commit adds logging for the full HTML response body in the `search` method of the `SongLyricsService`.

This will help diagnose why the search is not finding any results by allowing us to see the exact HTML that is being returned from `songlyrics.com`.